### PR TITLE
Bugfix #9939 - Alluring Siren targets now are forced to attack the player who played the effect

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AlluringSiren.java
+++ b/Mage.Sets/src/mage/cards/a/AlluringSiren.java
@@ -2,17 +2,21 @@
 
 package mage.cards.a;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.common.combat.AttacksIfAbleTargetEffect;
+import mage.abilities.effects.AttacksIfAbleYouTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -26,7 +30,7 @@ public final class AlluringSiren extends CardImpl {
         this.subtype.add(SubType.SIREN);
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AttacksIfAbleTargetEffect(Duration.EndOfTurn), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AttacksIfAbleYouTargetEffect(Duration.EndOfTurn), new TapSourceCost());
         ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }

--- a/Mage/src/main/java/mage/abilities/effects/AttacksIfAbleYouTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/AttacksIfAbleYouTargetEffect.java
@@ -1,0 +1,60 @@
+package mage.abilities.effects;
+
+import mage.abilities.Ability;
+import mage.abilities.Mode;
+import mage.constants.Duration;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+import java.util.UUID;
+/**
+ *
+ * @author FranzCorsaro
+ */
+public class AttacksIfAbleYouTargetEffect extends RequirementEffect {
+
+    public AttacksIfAbleYouTargetEffect(Duration duration) {
+        super(duration);
+    }
+
+    public AttacksIfAbleYouTargetEffect(RequirementEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public AttacksIfAbleYouTargetEffect copy() {
+        return new AttacksIfAbleYouTargetEffect(this);
+    }
+
+    @Override
+    public boolean applies(Permanent permanent, Ability source, Game game) {
+        return this.getTargetPointer().getTargets(game, source).contains(permanent.getId());
+    }
+
+
+    @Override
+    public UUID mustAttackDefender(Ability source, Game game) {
+        return source.getControllerId();
+    }
+
+    public boolean mustAttack(Game game) {
+        return true;
+    }
+
+    @Override
+    public boolean mustBlock(Game game) {
+        return false;
+    }
+
+    @Override
+    public String getText(Mode mode) {
+        if (staticText != null && !staticText.isEmpty()) {
+            return staticText;
+        }
+        if (this.duration == Duration.EndOfTurn) {
+            return "target " + mode.getTargets().get(0).getTargetName() + " attacks you this turn if able";
+        } else {
+            return "target " + mode.getTargets().get(0).getTargetName() + " attacks you each combat if able";
+        }
+    }
+}


### PR DESCRIPTION
Tested in 1v1, and 3 players free for all.
Probably could be tested in a better way.

- Added Effect AttacksIfAbleYouTargetEffect